### PR TITLE
Add support for BigDecimal

### DIFF
--- a/src/main/java/com/revinate/assertj/json/JsonPathAssert.java
+++ b/src/main/java/com/revinate/assertj/json/JsonPathAssert.java
@@ -4,6 +4,7 @@ import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.TypeRef;
 import org.assertj.core.api.*;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 /**
@@ -53,5 +54,15 @@ public class JsonPathAssert extends AbstractAssert<JsonPathAssert, DocumentConte
     public <T> AbstractListAssert<?, ? extends List<? extends T>, T> jsonPathAsListOf(String path, Class<T> type) {
         return Assertions.assertThat(actual.read(path, new TypeRef<List<T>>() {
         }));
+    }
+
+    /**
+     * Extracts a JSON number using a JsonPath expression and wrap it in an {@link BigDecimalAssert}
+     *
+     * @param path JsonPath to extract the number
+     * @return an instance of {@link BigDecimalAssert}
+     */
+    public AbstractBigDecimalAssert<?> jsonPathAsBigDecimal(String path) {
+        return Assertions.assertThat(actual.read(path, BigDecimal.class));
     }
 }

--- a/src/test/java/com/revinate/assertj/json/JsonPathAssertTest.java
+++ b/src/test/java/com/revinate/assertj/json/JsonPathAssertTest.java
@@ -5,6 +5,8 @@ import com.jayway.jsonpath.JsonPath;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.math.BigDecimal;
+
 import static com.revinate.assertj.json.JsonPathAssert.assertThat;
 
 public class JsonPathAssertTest {
@@ -33,5 +35,12 @@ public class JsonPathAssertTest {
         DocumentContext documentContext = JsonPath.parse("[1,2,3]");
 
         assertThat(documentContext).jsonPathAsListOf("$", Integer.class).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    public void jsonPathAsBigDecimal_shouldReadNumericValue() throws Exception {
+        DocumentContext documentContext = JsonPath.parse("0.3");
+
+        assertThat(documentContext).jsonPathAsBigDecimal("$").isEqualTo(new BigDecimal("0.3"));
     }
 }


### PR DESCRIPTION
As JSON only knows about numbers (which can be floats or larger than `int`/`Integer`) this adds another `assertThat`-Method for parsing a value into a `BigDecimal`.