### PR TITLE
Upgrade to assertj-core 3.11.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.assertj:assertj-core:3.8.0'
+    compile 'org.assertj:assertj-core:3.11.1'
     compile 'com.fasterxml.jackson.core:jackson-core:2.6.3'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.6.3'
     compile 'com.jayway.jsonpath:json-path:2.4.0'

--- a/src/main/java/com/revinate/assertj/json/JsonPathAssert.java
+++ b/src/main/java/com/revinate/assertj/json/JsonPathAssert.java
@@ -28,7 +28,7 @@ public class JsonPathAssert extends AbstractAssert<JsonPathAssert, DocumentConte
      * @param path JsonPath to extract the string
      * @return an instance of {@link StringAssert}
      */
-    public AbstractCharSequenceAssert<?, String> jsonPathAsString(String path) {
+    public AbstractStringAssert<?> jsonPathAsString(String path) {
         return Assertions.assertThat(actual.read(path, String.class));
     }
 


### PR DESCRIPTION
Bump to assertj-core 3.11.1 to resolve `NoSuchMethodError`s after a signature changes in assertj-core.

Fixes #13 
